### PR TITLE
Fix leaking options var.

### DIFF
--- a/vendor/handlebars.runtime-1.0.0.beta.6.js
+++ b/vendor/handlebars.runtime-1.0.0.beta.6.js
@@ -204,7 +204,7 @@ Handlebars.VM = {
   },
   noop: function() { return ""; },
   invokePartial: function(partial, name, context, helpers, partials, data) {
-    options = { helpers: helpers, partials: partials, data: data };
+    var options = { helpers: helpers, partials: partials, data: data };
 
     if(partial === undefined) {
       throw new Handlebars.Exception("The partial " + name + " could not be found");


### PR DESCRIPTION
In place of upgrading the entire handlebars runtime and npm, just add the var statement for now.
