### PR TITLE
minor README cosmetics for `git` url example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Add `"handlebars-brunch": "x.y.z"` to `package.json` of your brunch app.
 Pick a plugin version that corresponds to your minor (y) brunch version.
 
 If you want to use git version of plugin, add
-`"handlebars-brunch": "git+ssh://git@github.com:brunch/handlebars-brunch.git"`.
+`"handlebars-brunch": "git+https://github.com/brunch/handlebars-brunch.git"`.


### PR DESCRIPTION
This updates the README example of using the `git` repro with the `git+https` URL instead of `git+ssh` as the repro seems to be read-only. Otherwise `git://` would work as well. Using the `git+ssh` (read-write) example was giving 'public key' access errors.
