### PR TITLE
Strip leading/trailing whitespace on optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,11 @@ HandlebarsCompiler.prototype.pattern = /\.(?:hbs|handlebars)$/;
 HandlebarsCompiler.prototype.pathReplace = /^.*templates\//;
 
 HandlebarsCompiler.prototype.compile = function(data, path, callback) {
+  if (this.optimize) {
+    data = data.replace(/^[\x20\t]+/mg, '').replace(/[\x20\t]+$/mg, '');
+    data = data.replace(/^[\r\n]+/, '').replace(/[\r\n]*$/, '\n');
+  }
+
   var error, key, ns, result, source;
   try {
     source = "Handlebars.template(" + (handlebars.precompile(data)) + ")";


### PR DESCRIPTION
Replacements taken from https://github.com/gruntjs/grunt-contrib-handlebars#processcontent
