### PR TITLE
Fix compilation in production mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class HandlebarsCompiler {
   }
 
   compile(params) {
-    const data = params.data;
+    let data = params.data;
     const path = params.path;
 
     if (this.optimize) {


### PR DESCRIPTION
f31d74e62bb888c6719ee12a0f52ca55dbbfdd8d introduced some ES6 to clean up the code a bit, unfortunately, this breaks when the plugin is called with `optimize` set to true, because the `compile` method try to mutate the `data` var. 