### PR TITLE
Declare handlebars as a peerDependencie

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,15 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
-    "handlebars": ">=2.0.0 <5.0.0",
     "umd-wrapper": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "1.11.0",
     "chai": "1.7.0",
-    "eslint": "^2.1.0"
+    "eslint": "^2.1.0",
+    "handlebars": ">=2.0.0 <5.0.0"
+  },
+  "peerDependencies": {
+    "handlebars": ">=2.0.0 <5.0.0"
   }
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -7,6 +7,12 @@ var fs = require('fs');
 
 var dist = sysPath.join(__dirname, 'dist');
 
+process.on('uncaughtException', function (e) {
+  if (e.code == 'MODULE_NOT_FOUND') {
+    console.log('You need to have handlebars installed for the handlebars-brunch plugin');
+  }
+})
+
 if (!fs.existsSync(dist)) {
   fs.mkdirSync(dist);
 }
@@ -26,4 +32,3 @@ runtime.forEach(function(r) {
     });
   });
 });
-

--- a/postinstall.js
+++ b/postinstall.js
@@ -9,7 +9,7 @@ var dist = sysPath.join(__dirname, 'dist');
 
 process.on('uncaughtException', function (e) {
   if (e.code == 'MODULE_NOT_FOUND') {
-    console.log('You need to have handlebars installed for the handlebars-brunch plugin');
+    console.log('\x1b[31m', 'You need to have handlebars installed for the handlebars-brunch plugin' ,'\x1b[0m');
   }
 })
 


### PR DESCRIPTION
This is based on some off-topic discussion in #39, and not intended to be merge as-is but just to open the discussion.

For now, the range specified for handlebars is pretty liberal. This can easily lead to a mismatch of  version installed on a dev machine and on the CI or between team members.

By declaring it as a peerDepencie, this allows dev to have full control over witch version of the runtime they want, but by keeping the same range used today, we stay sure that any change in handlebars compilation API wont break the plugin.

FWIW, this is the approach used by the karma ecosystem and it works pretty well. See for exemple the [karma-jasmine package.json](https://github.com/karma-runner/karma-jasmine/blob/631f42df5d4ef12d773fdd6671310799bc58ca73/package.json)
